### PR TITLE
Lenient location of catalog.xml

### DIFF
--- a/jvm/src/main/scala/eu/cdevreeze/tqa/docbuilder/jvm/TaxonomyPackagePartialUriResolvers.scala
+++ b/jvm/src/main/scala/eu/cdevreeze/tqa/docbuilder/jvm/TaxonomyPackagePartialUriResolvers.scala
@@ -51,7 +51,7 @@ object TaxonomyPackagePartialUriResolvers {
     val catalogEntry: ZipEntry = zipFile
       .entries()
       .asScala
-      .find(entry => toRelativeUri(entry).toString.endsWith("META-INF/catalog.xml"))
+      .find(entry => entry.getName.endsWith("catalog.xml"))
       .getOrElse(sys.error(s"No META-INF/catalog.xml found in taxonomy package ZIP file ${zipFile.getName}"))
 
     val catalogEntryRelativeUri: URI = toRelativeUri(catalogEntry).ensuring(!_.isAbsolute)


### PR DESCRIPTION
Proposed solution for issue #4.
This solution is perhaps to lenient for your taste, as it does not validate whether there is only one such catalog file, nor whether there is only one parent path above it (let alone the entire zip is living inside a single explicit folder).